### PR TITLE
add securerandom and fix a ipa without icons when use `icons` methods

### DIFF
--- a/lib/lagunitas/app.rb
+++ b/lib/lagunitas/app.rb
@@ -42,6 +42,8 @@ module Lagunitas
           icons << get_image("#{name}@2x")
         end
         icons.delete_if { |i| !i }
+      rescue NoMethodError # fix a ipa without icons
+        []
       end
     end
 

--- a/lib/lagunitas/app.rb
+++ b/lib/lagunitas/app.rb
@@ -15,6 +15,10 @@ module Lagunitas
       info['CFBundleIdentifier']
     end
 
+    def bundle_name
+      info['CFBundleName']
+    end
+
     def display_name
       info['CFBundleDisplayName']
     end

--- a/lib/lagunitas/ipa.rb
+++ b/lib/lagunitas/ipa.rb
@@ -1,5 +1,6 @@
 require 'zip'
 require 'fileutils'
+require 'securerandom'
 
 module Lagunitas
   class IPA


### PR DESCRIPTION
fix `NameError: uninitialized constant Lagunitas::IPA::SecureRandom`